### PR TITLE
remove extra parentheses from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
   - [Radix UI](https://radix-ui.com) for headless component primitives
   - Icons from [Phosphor Icons](https://phosphoricons.com)
 - Chat History, rate limiting, and session storage with [Vercel KV](https://vercel.com/storage/kv)
-- [Next Auth](https://github.com/nextauthjs/next-auth)) for authentication
+- [Next Auth](https://github.com/nextauthjs/next-auth) for authentication
 
 ## Model Providers
 


### PR DESCRIPTION
fixes a typo basically