### PR TITLE
fix: Fix metadata title generation in chat pages

### DIFF
--- a/app/chat/[id]/page.tsx
+++ b/app/chat/[id]/page.tsx
@@ -25,7 +25,7 @@ export async function generateMetadata({
 
   const chat = await getChat(params.id, session.user.id)
   return {
-    title: chat?.title.slice(0, 50) ?? 'Chat'
+    title: chat?.title.toString().slice(0, 50) ?? 'Chat'
   }
 }
 


### PR DESCRIPTION
### Description
- Fix a potential error in generating metadata title in chat page. 
- Improves app stability and user experience.

### Linked Issues:
   - #40 