### PR TITLE
fix: Adds max height to form box

### DIFF
--- a/components/prompt-form.tsx
+++ b/components/prompt-form.tsx
@@ -46,7 +46,7 @@ export function PromptForm({
       }}
       ref={formRef}
     >
-      <div className="relative flex w-full grow flex-col overflow-hidden bg-background px-8 sm:rounded-md sm:border sm:px-12">
+      <div className="relative flex max-h-60 w-full grow flex-col overflow-hidden bg-background px-8 sm:rounded-md sm:border sm:px-12">
         <Tooltip>
           <TooltipTrigger asChild>
             <Link


### PR DESCRIPTION
Fixes form box by adding max-height, due to UI breaking when there's a large prompt, fix works on mobile and desktop.

Changes
* Adds max-height to form box due to UI breaking when having large prompts

Before:

https://github.com/vercel-labs/ai-chatbot/assets/5727631/188b6896-4f6b-4b4a-bf6f-f44a4877910f

After:

https://github.com/vercel-labs/ai-chatbot/assets/5727631/8a351ab4-4488-4f31-b636-44f979cfd98a

