### PR TITLE
chore: upgrade `next-auth`

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -15,7 +15,6 @@ export const {
   auth,
   CSRF_experimental
 } = NextAuth({
-  // @ts-expect-error
   providers: [GitHub],
   callbacks: {
     jwt: async ({ token, profile }) => {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "focus-trap-react": "^10.1.1",
     "nanoid": "^4.0.2",
     "next": "13.4.7-canary.1",
-    "next-auth": "0.0.0-manual.f414f2f5",
+    "next-auth": "0.0.0-manual.e65faa1c",
     "next-themes": "^0.2.1",
     "openai-edge": "^0.5.1",
     "react": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ dependencies:
     specifier: 13.4.7-canary.1
     version: 13.4.7-canary.1(react-dom@18.2.0)(react@18.2.0)
   next-auth:
-    specifier: 0.0.0-manual.f414f2f5
-    version: 0.0.0-manual.f414f2f5(next@13.4.7-canary.1)(react-dom@18.2.0)(react@18.2.0)
+    specifier: 0.0.0-manual.e65faa1c
+    version: 0.0.0-manual.e65faa1c(next@13.4.7-canary.1)(react-dom@18.2.0)(react@18.2.0)
   next-themes:
     specifier: ^0.2.1
     version: 0.2.1(next@13.4.7-canary.1)(react-dom@18.2.0)(react@18.2.0)
@@ -165,8 +165,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /@auth/core@0.0.0-manual.527fff6c:
-    resolution: {integrity: sha512-NYWuH+6VAAMV05juyarbMm6rCDUGvS5vPFsE+V13NIfbvbwbEZPj3JfcHVv7vMDrUrPtJ4EhTh00Svejp1Moqg==}
+  /@auth/core@0.0.0-manual.8fcd46b0:
+    resolution: {integrity: sha512-KuhvZ0hHz6NvMAgAi+su0dJOD0YAiOWGaLswyfGK5RsG/cdhqyyiII9HOTaZbWZAKir0UGYb8SlN+owhV30JXg==}
     peerDependencies:
       nodemailer: ^6.8.0
     peerDependenciesMeta:
@@ -181,29 +181,13 @@ packages:
       preact-render-to-string: 5.2.3(preact@10.11.3)
     dev: false
 
-  /@auth/core@0.8.2:
-    resolution: {integrity: sha512-swqJ7tKFlqiYIl1znFGrrawUv1F6rwL+/f3DoeWDaZLnr2phiHFaZsvNvLK7WBJhnJbel78Vd3GznuR31AnFUw==}
-    peerDependencies:
-      nodemailer: ^6.8.0
-    peerDependenciesMeta:
-      nodemailer:
-        optional: true
-    dependencies:
-      '@panva/hkdf': 1.1.1
-      cookie: 0.5.0
-      jose: 4.14.4
-      oauth4webapi: 2.3.0
-      preact: 10.11.3
-      preact-render-to-string: 5.2.3(preact@10.11.3)
-    dev: false
-
-  /@auth/nextjs@0.0.0-manual.de744368(next@13.4.7-canary.1)(react@18.2.0):
-    resolution: {integrity: sha512-jLjKasLTKH5YLiK2i0NQWbsQS1pMveidyFT/ibwZ6c5UAcqDsC6ZGvvVxOaiAmiA6iFA1WMqNBVEcy+NhGgXVQ==}
+  /@auth/nextjs@0.0.0-manual.b53ca00b(next@13.4.7-canary.1)(react@18.2.0):
+    resolution: {integrity: sha512-g0XvlP+3MSXPX512K6Hu0mGOkb1QPCkXkaA0Zr9i+bmTEDU9TtYTTNmX2EyvLeTfmrEEU/CMS92aWTmiki1KVA==}
     peerDependencies:
       next: ^13.4.6
       react: ^18.2.0
     dependencies:
-      '@auth/core': 0.8.2
+      '@auth/core': 0.0.0-manual.8fcd46b0
       next: 13.4.7-canary.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
@@ -4033,8 +4017,8 @@ packages:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
     dev: true
 
-  /next-auth@0.0.0-manual.f414f2f5(next@13.4.7-canary.1)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-qJmSX4QUV8V2JOQavl0fQyJymt0fte7eDQsMGTpx8ZRU2Qvx8uh+xrvXlHt3dXf603OB3QkWaj77ipIEt62Hfg==}
+  /next-auth@0.0.0-manual.e65faa1c(next@13.4.7-canary.1)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-I51GvhZhZEf/gzhiTKivYPAIyZ74sCF3YXAMMuZ/bjahybeehPEu7opcPEA+H0Uxrvmo2G8/BQ7mT+TiFdM9IQ==}
     peerDependencies:
       next: ^13.4.5
       nodemailer: ^6.6.5
@@ -4044,8 +4028,7 @@ packages:
       nodemailer:
         optional: true
     dependencies:
-      '@auth/core': 0.0.0-manual.527fff6c
-      '@auth/nextjs': 0.0.0-manual.de744368(next@13.4.7-canary.1)(react@18.2.0)
+      '@auth/nextjs': 0.0.0-manual.b53ca00b(next@13.4.7-canary.1)(react@18.2.0)
       next: 13.4.7-canary.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)


### PR DESCRIPTION
remove the last `@ts-ignore`

Incorporates the fix from https://github.com/nextauthjs/next-auth/commit/8fcd46b0fc5ea9c5418aca267a187b9f4da80a8d