### PR TITLE
clearChats

### DIFF
--- a/app/actions.ts
+++ b/app/actions.ts
@@ -74,7 +74,9 @@ export async function clearChats() {
   }
 
   const chats: string[] = await kv.zrange(`user:chat:${session.user.id}`, 0, -1)
-
+  if (!chats.length) {
+  return redirect('/')
+  }
   const pipeline = kv.pipeline()
 
   for (const chat of chats) {


### PR DESCRIPTION
check chats length before run kv.pipeline() otherwise get empty pipeline, we get this error when there is no chats in storage