### PR TITLE
fix: Do not send empty messages.

### DIFF
--- a/components/prompt-form.tsx
+++ b/components/prompt-form.tsx
@@ -15,7 +15,7 @@ import { IconArrowElbow, IconPlus } from '@/components/ui/icons'
 
 export interface PromptProps
   extends Pick<UseChatHelpers, 'input' | 'setInput'> {
-  onSubmit: (value: string) => void
+  onSubmit: (value: string) => Promise<void>
   isLoading: boolean
 }
 
@@ -38,7 +38,7 @@ export function PromptForm({
     <form
       onSubmit={async e => {
         e.preventDefault()
-        if (input === '') {
+        if (!input?.trim()) {
           return
         }
         setInput('')


### PR DESCRIPTION
Users should not be able to send empty messages to chat GPT, as this would not be of any help.