### PR TITLE
chore: upgrade `@auth/nextjs`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ packages:
     engines: {node: '>=10'}
     dev: true
 
-  /@auth/core@0.0.0-manual.527fff6c:
-    resolution: {integrity: sha512-NYWuH+6VAAMV05juyarbMm6rCDUGvS5vPFsE+V13NIfbvbwbEZPj3JfcHVv7vMDrUrPtJ4EhTh00Svejp1Moqg==}
+  /@auth/core@0.0.0-manual.8fcd46b0:
+    resolution: {integrity: sha512-KuhvZ0hHz6NvMAgAi+su0dJOD0YAiOWGaLswyfGK5RsG/cdhqyyiII9HOTaZbWZAKir0UGYb8SlN+owhV30JXg==}
     peerDependencies:
       nodemailer: ^6.8.0
     peerDependenciesMeta:
@@ -181,29 +181,13 @@ packages:
       preact-render-to-string: 5.2.3(preact@10.11.3)
     dev: false
 
-  /@auth/core@0.8.2:
-    resolution: {integrity: sha512-swqJ7tKFlqiYIl1znFGrrawUv1F6rwL+/f3DoeWDaZLnr2phiHFaZsvNvLK7WBJhnJbel78Vd3GznuR31AnFUw==}
-    peerDependencies:
-      nodemailer: ^6.8.0
-    peerDependenciesMeta:
-      nodemailer:
-        optional: true
-    dependencies:
-      '@panva/hkdf': 1.1.1
-      cookie: 0.5.0
-      jose: 4.14.4
-      oauth4webapi: 2.3.0
-      preact: 10.11.3
-      preact-render-to-string: 5.2.3(preact@10.11.3)
-    dev: false
-
-  /@auth/nextjs@0.0.0-manual.de744368(next@13.4.7-canary.1)(react@18.2.0):
-    resolution: {integrity: sha512-jLjKasLTKH5YLiK2i0NQWbsQS1pMveidyFT/ibwZ6c5UAcqDsC6ZGvvVxOaiAmiA6iFA1WMqNBVEcy+NhGgXVQ==}
+  /@auth/nextjs@0.0.0-manual.179c08d4(next@13.4.7-canary.1)(react@18.2.0):
+    resolution: {integrity: sha512-HVuDgb6xlYLV5mHTGc0Pycg8BlwtcvjvS+54QXEbOBpA5tulzKxAH8QlCoKj5R9XHW9hP9DiCnvXyVV9x2N+jA==}
     peerDependencies:
       next: ^13.4.6
       react: ^18.2.0
     dependencies:
-      '@auth/core': 0.8.2
+      '@auth/core': 0.0.0-manual.8fcd46b0
       next: 13.4.7-canary.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
     transitivePeerDependencies:
@@ -4044,8 +4028,8 @@ packages:
       nodemailer:
         optional: true
     dependencies:
-      '@auth/core': 0.0.0-manual.527fff6c
-      '@auth/nextjs': 0.0.0-manual.de744368(next@13.4.7-canary.1)(react@18.2.0)
+      '@auth/core': 0.0.0-manual.8fcd46b0
+      '@auth/nextjs': 0.0.0-manual.179c08d4(next@13.4.7-canary.1)(react@18.2.0)
       next: 13.4.7-canary.1(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)


### PR DESCRIPTION
https://github.com/nextauthjs/next-auth/pull/7443/commits/179c08d45ba0ca63addeb807afd4ff572cfd5dc7

Spent two hours on this. <picture data-single-emoji=":upside_down_cry:" title=":upside_down_cry:"><img class="emoji" width="20" height="auto" src="https://emoji.slack-edge.com/T0CAQ00TU/upside_down_cry/feeefabbbcaa4067.png" alt=":upside_down_cry:" align="absmiddle"></picture>
The `x-forwarded-proto` header returns `https`, but `URL#protocol` returns `https:`.

This made our cookies not being properly set in secure (HTTPS) environments, causing various issues when deployed.

Fixes #28

You can run `pnpm up @auth/nextjs` in your own project to apply this fix.