### PR TITLE
fix: multiple chat creation bug

### DIFF
--- a/components/prompt-form.tsx
+++ b/components/prompt-form.tsx
@@ -1,17 +1,17 @@
-import * as React from 'react'
-import Link from 'next/link'
-import Textarea from 'react-textarea-autosize'
 import { UseChatHelpers } from 'ai/react'
+import * as React from 'react'
+import Textarea from 'react-textarea-autosize'
 
-import { useEnterSubmit } from '@/lib/hooks/use-enter-submit'
-import { cn } from '@/lib/utils'
 import { Button, buttonVariants } from '@/components/ui/button'
+import { IconArrowElbow, IconPlus } from '@/components/ui/icons'
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger
 } from '@/components/ui/tooltip'
-import { IconArrowElbow, IconPlus } from '@/components/ui/icons'
+import { useEnterSubmit } from '@/lib/hooks/use-enter-submit'
+import { cn } from '@/lib/utils'
+import { useRouter } from 'next/navigation'
 
 export interface PromptProps
   extends Pick<UseChatHelpers, 'input' | 'setInput'> {
@@ -27,6 +27,7 @@ export function PromptForm({
 }: PromptProps) {
   const { formRef, onKeyDown } = useEnterSubmit()
   const inputRef = React.useRef<HTMLTextAreaElement>(null)
+  const router = useRouter()
 
   React.useEffect(() => {
     if (inputRef.current) {
@@ -49,8 +50,12 @@ export function PromptForm({
       <div className="relative flex max-h-60 w-full grow flex-col overflow-hidden bg-background px-8 sm:rounded-md sm:border sm:px-12">
         <Tooltip>
           <TooltipTrigger asChild>
-            <Link
-              href="/"
+            <button
+              onClick={e => {
+                e.preventDefault()
+                router.refresh()
+                router.push('/')
+              }}
               className={cn(
                 buttonVariants({ size: 'sm', variant: 'outline' }),
                 'absolute left-0 top-4 h-8 w-8 rounded-full bg-background p-0 sm:left-4'
@@ -58,7 +63,7 @@ export function PromptForm({
             >
               <IconPlus />
               <span className="sr-only">New Chat</span>
-            </Link>
+            </button>
           </TooltipTrigger>
           <TooltipContent>New Chat</TooltipContent>
         </Tooltip>


### PR DESCRIPTION
Partially fix #79 by allowing for multiple chat creation with the expected behavior.

However, the other part of the issue is to update the chat list with the recently initiated chat. But to fix this we need to refetch the values from getChats after initiating a chat, and this may require to rethink how the ChatList component was done, but I'm not sure.