### PR TITLE
Fix tailwind class order warnings

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -43,10 +43,10 @@ export default function RootLayout({ children }: RootLayoutProps) {
       >
         <Toaster />
         <Providers attribute="class" defaultTheme="system" enableSystem>
-          <div className="flex flex-col min-h-screen">
+          <div className="flex min-h-screen flex-col">
             {/* @ts-ignore */}
             <Header />
-            <main className="flex flex-col flex-1 bg-muted/50">{children}</main>
+            <main className="flex flex-1 flex-col bg-muted/50">{children}</main>
           </div>
           <TailwindIndicator />
         </Providers>

--- a/app/share/[id]/page.tsx
+++ b/app/share/[id]/page.tsx
@@ -35,8 +35,8 @@ export default async function SharePage({ params }: SharePageProps) {
   return (
     <>
       <div className="flex-1 space-y-6">
-        <div className="px-4 py-6 border-b bg-background md:px-6 md:py-8">
-          <div className="max-w-2xl mx-auto md:px-6">
+        <div className="border-b bg-background px-4 py-6 md:px-6 md:py-8">
+          <div className="mx-auto max-w-2xl md:px-6">
             <div className="space-y-1 md:-mx-8">
               <h1 className="text-2xl font-bold">{chat.title}</h1>
               <div className="text-sm text-muted-foreground">

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -22,7 +22,7 @@ import { LoginButton } from '@/components/login-button'
 export async function Header() {
   const session = await auth()
   return (
-    <header className="sticky top-0 z-50 flex items-center justify-between w-full h-16 px-4 border-b shrink-0 bg-gradient-to-b from-background/10 via-background/50 to-background/80 backdrop-blur-xl">
+    <header className="sticky top-0 z-50 flex h-16 w-full shrink-0 items-center justify-between border-b bg-gradient-to-b from-background/10 via-background/50 to-background/80 px-4 backdrop-blur-xl">
       <div className="flex items-center">
         {session?.user ? (
           <Sidebar>
@@ -37,12 +37,12 @@ export async function Header() {
           </Sidebar>
         ) : (
           <Link href="/" target="_blank" rel="nofollow">
-            <IconNextChat className="w-6 h-6 mr-2 dark:hidden" inverted />
-            <IconNextChat className="hidden w-6 h-6 mr-2 dark:block" />
+            <IconNextChat className="mr-2 h-6 w-6 dark:hidden" inverted />
+            <IconNextChat className="mr-2 hidden h-6 w-6 dark:block" />
           </Link>
         )}
         <div className="flex items-center">
-          <IconSeparator className="w-6 h-6 text-muted-foreground/50" />
+          <IconSeparator className="h-6 w-6 text-muted-foreground/50" />
           {session?.user ? (
             <UserMenu user={session.user} />
           ) : (
@@ -60,7 +60,7 @@ export async function Header() {
           className={cn(buttonVariants({ variant: 'outline' }))}
         >
           <IconGitHub />
-          <span className="hidden ml-2 md:flex">GitHub</span>
+          <span className="ml-2 hidden md:flex">GitHub</span>
         </a>
         <a
           href="https://github.com/vercel/nextjs-ai-chatbot/"

--- a/components/ui/sheet.tsx
+++ b/components/ui/sheet.tsx
@@ -49,7 +49,7 @@ const SheetContent = React.forwardRef<
     <SheetPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed inset-y-0 left-0 z-50 h-full border-r bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left data-[state=closed]:duration-300 data-[state=open]:duration-500 sm:max-w-sm',
+        'fixed inset-y-0 left-0 z-50 h-full border-r bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
         className
       )}
       {...props}

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -31,12 +31,12 @@ export function UserMenu({ user }: UserMenuProps) {
           <Button variant="ghost" className="pl-0">
             {user?.image ? (
               <Image
-                className="w-6 h-6 transition-opacity duration-300 rounded-full select-none ring-1 ring-zinc-100/10 hover:opacity-80"
+                className="h-6 w-6 select-none rounded-full ring-1 ring-zinc-100/10 transition-opacity duration-300 hover:opacity-80"
                 src={user?.image ? `${user.image}&s=60` : ''}
                 alt={user.name ?? 'Avatar'}
               />
             ) : (
-              <div className="flex items-center justify-center text-xs font-medium uppercase rounded-full select-none h-7 w-7 shrink-0 bg-muted/50 text-muted-foreground">
+              <div className="flex h-7 w-7 shrink-0 select-none items-center justify-center rounded-full bg-muted/50 text-xs font-medium uppercase text-muted-foreground">
                 {user?.name ? getUserInitials(user?.name) : null}
               </div>
             )}
@@ -54,10 +54,10 @@ export function UserMenu({ user }: UserMenuProps) {
               href="https://vercel.com"
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center justify-between w-full text-xs"
+              className="inline-flex w-full items-center justify-between text-xs"
             >
               Vercel Homepage
-              <IconExternalLink className="w-3 h-3 ml-auto" />
+              <IconExternalLink className="ml-auto h-3 w-3" />
             </a>
           </DropdownMenuItem>
           <DropdownMenuItem


### PR DESCRIPTION
# The Issue

There are lint warnings for tailwind css classes being out of order

Super minor but these warnings show up in the build process, and when a user is trying to deploy on vercel. Let's get rid of them.

<img width="851" alt="Screenshot 2023-07-30 at 7 40 00 PM" src="https://github.com/vercel-labs/ai-chatbot/assets/12915163/dfb42ab0-8702-4a6a-a373-5ce1e5c67944">

# Proposed Change
`npm run lint -- --fix` 😉

There is no functional impact from reordering these classes.