### PR TITLE
fix: User Image returned from auth provider

### DIFF
--- a/auth.ts
+++ b/auth.ts
@@ -20,7 +20,7 @@ export const {
     jwt({ token, profile }) {
       if (profile) {
         token.id = profile.id
-        token.image = profile.picture
+        token.image = profile.avatar_url || profile.picture
       }
       return token
     },


### PR DESCRIPTION
Github auth provider doesn't return back a `picture` prop like Google. instead, it returns `avatar_url`.

<details>
<summary>Here is an instance of the data returned</summary>

```json
{
  "login": "A7med3bdulBaset",
  "id": 000000,
  "node_id": "00000000000000000",
  "avatar_url": "https://avatars.githubusercontent.com/u/82659015?v=4",
  "gravatar_id": "",
  "url": "https://api.github.com/users/A7med3bdulBaset",
  "html_url": "https://github.com/A7med3bdulBaset",
  "followers_url": "https://api.github.com/users/A7med3bdulBaset/followers",
  "following_url": "https://api.github.com/users/A7med3bdulBaset/following{/other_user}",
  "gists_url": "https://api.github.com/users/A7med3bdulBaset/gists{/gist_id}",
  "starred_url": "https://api.github.com/users/A7med3bdulBaset/starred{/owner}{/repo}",
  "subscriptions_url": "https://api.github.com/users/A7med3bdulBaset/subscriptions",
  "organizations_url": "https://api.github.com/users/A7med3bdulBaset/orgs",
  "repos_url": "https://api.github.com/users/A7med3bdulBaset/repos",
  "events_url": "https://api.github.com/users/A7med3bdulBaset/events{/privacy}",
  "received_events_url": "https://api.github.com/users/A7med3bdulBaset/received_events",
  "type": "User",
  "site_admin": false,
  "name": "Ahmed Abdelbaset",
  "company": null,
  "blog": "",
  "location": "Egypt",
  "email": "A7med3bdulBaset@gmail.com",
  "hireable": true,
  "bio": "Learn new things every day!",
  "twitter_username": "A7med3bdulBaset",
  "public_repos": 37,
  "public_gists": 0,
  "followers": 173,
  "following": 86,
  "created_at": "2021-04-16T12:58:21Z",
  "updated_at": "2023-07-22T23:11:08Z",
  "private_gists": 1,
  "total_private_repos": 12,
  "owned_private_repos": 12,
  "disk_usage": 464381,
  "collaborators": 1,
  "two_factor_authentication": false,
  "plan": {
    "name": "pro",
    "space": 0000000,
    "collaborators": 0,
    "private_repos": 9999
  }
}

```
</details>