### PR TITLE
Fix use-local-storage.ts

### DIFF
--- a/lib/hooks/use-local-storage.ts
+++ b/lib/hooks/use-local-storage.ts
@@ -1,26 +1,26 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 
 export const useLocalStorage = <T>(
   key: string,
   initialValue: T
 ): [T, (value: T) => void] => {
 
-  // prevent usage server-side
-  if (typeof window === 'undefined') {
-    return [initialValue, () => undefined]
-  }
-  
-  // Initialize the state using a function to avoid unnecessary re-render
   const [storedValue, setStoredValue] = useState<T>(() => {
-    const item = window.localStorage.getItem(key)
-    return item ? JSON.parse(item) : initialValue
+    if (typeof window !== 'undefined') {
+      const item = window.localStorage.getItem(key)
+      return item ? JSON.parse(item) : initialValue
+    }
+    return initialValue
   })
 
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(key, JSON.stringify(storedValue))
+    }
+  }, [storedValue, key])
+
   const setValue = (value: T) => {
-    // Save state
     setStoredValue(value)
-    // Save to localStorage
-    window.localStorage.setItem(key, JSON.stringify(value))
   }
 
   return [storedValue, setValue]

--- a/lib/hooks/use-local-storage.ts
+++ b/lib/hooks/use-local-storage.ts
@@ -22,6 +22,5 @@ export const useLocalStorage = <T>(
     // Save state
     setStoredValue(value)
   }
-
   return [storedValue, setValue]
 }

--- a/lib/hooks/use-local-storage.ts
+++ b/lib/hooks/use-local-storage.ts
@@ -5,6 +5,11 @@ export const useLocalStorage = <T>(
   initialValue: T
 ): [T, (value: T) => void] => {
 
+  // prevent usage server-side
+  if (typeof window === 'undefined') {
+    return [initialValue, () => undefined]
+  }
+  
   // Initialize the state using a function to avoid unnecessary re-render
   const [storedValue, setStoredValue] = useState<T>(() => {
     const item = window.localStorage.getItem(key)

--- a/lib/hooks/use-local-storage.ts
+++ b/lib/hooks/use-local-storage.ts
@@ -1,18 +1,15 @@
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 
 export const useLocalStorage = <T>(
   key: string,
   initialValue: T
 ): [T, (value: T) => void] => {
-  const [storedValue, setStoredValue] = useState(initialValue)
 
-  useEffect(() => {
-    // Retrieve from localStorage
+  // Initialize the state using a function to avoid unnecessary re-render
+  const [storedValue, setStoredValue] = useState<T>(() => {
     const item = window.localStorage.getItem(key)
-    if (item) {
-      setStoredValue(JSON.parse(item))
-    }
-  }, [key])
+    return item ? JSON.parse(item) : initialValue
+  })
 
   const setValue = (value: T) => {
     // Save state
@@ -20,5 +17,6 @@ export const useLocalStorage = <T>(
     // Save to localStorage
     window.localStorage.setItem(key, JSON.stringify(value))
   }
+
   return [storedValue, setValue]
 }

--- a/lib/hooks/use-local-storage.ts
+++ b/lib/hooks/use-local-storage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 export const useLocalStorage = <T>(
   key: string,

--- a/lib/hooks/use-local-storage.ts
+++ b/lib/hooks/use-local-storage.ts
@@ -1,25 +1,20 @@
-import { useEffect, useState } from 'react'
+import { useState, useEffect } from 'react'
 
 export const useLocalStorage = <T>(
   key: string,
   initialValue: T
 ): [T, (value: T) => void] => {
   const [storedValue, setStoredValue] = useState<T>(() => {
-    if (typeof window !== 'undefined') {
-      const item = window.localStorage.getItem(key)
-      return item ? JSON.parse(item) : initialValue
-    }
-    return initialValue
+    // causes ReferenceError: window is not defined but avoids hydration error
+    const item = window.localStorage.getItem(key)
+    return item ? JSON.parse(item) : initialValue
   })
 
   useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.localStorage.setItem(key, JSON.stringify(storedValue))
-    }
+    window.localStorage.setItem(key, JSON.stringify(storedValue))
   }, [storedValue, key])
 
   const setValue = (value: T) => {
-    // Save state
     setStoredValue(value)
   }
   return [storedValue, setValue]

--- a/lib/hooks/use-local-storage.ts
+++ b/lib/hooks/use-local-storage.ts
@@ -1,10 +1,9 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 export const useLocalStorage = <T>(
   key: string,
   initialValue: T
 ): [T, (value: T) => void] => {
-
   const [storedValue, setStoredValue] = useState<T>(() => {
     if (typeof window !== 'undefined') {
       const item = window.localStorage.getItem(key)
@@ -20,6 +19,7 @@ export const useLocalStorage = <T>(
   }, [storedValue, key])
 
   const setValue = (value: T) => {
+    // Save state
     setStoredValue(value)
   }
 


### PR DESCRIPTION
Fix use-local-storage hook.  Existing implementation does not work.  Causes an additional re-render or resets to `INITIAL_VALUE` before accessing the stored state in local storage.