### PR TITLE
Disable selection on code block line numbers

### DIFF
--- a/components/ui/codeblock.tsx
+++ b/components/ui/codeblock.tsx
@@ -128,6 +128,9 @@ const CodeBlock: FC<Props> = memo(({ language, value }) => {
           background: 'transparent',
           padding: '1.5rem 1rem'
         }}
+        lineNumberStyle={{
+          userSelect: "none",
+        }}
         codeTagProps={{
           style: {
             fontSize: '0.9rem',


### PR DESCRIPTION
Currently, selecting the code block will also select the line number, making the copied content look like this:

```
1const response = new Response('Auth Required.', {
2  status: 401,
3  headers: {
4    'WWW-authenticate': 'Basic realm="Secure Area"'
5  }
6});
```

This PR tries to fix that.

(Yes I know the copy button exists but say people might want to select only part of the code block.)

**Disclaimer:** I never tested this code – this PR was made on a whim entirely using GitHub UI, because I faced this problem while I was using chat.vercel.ai. I only hope that this works – sorry for that 😅